### PR TITLE
C++ interface for sphactor

### DIFF
--- a/include/libsphactor.h
+++ b/include/libsphactor.h
@@ -18,6 +18,9 @@
 #include "sphactor_library.h"
 
 //  Add your own public definitions here, if you need them
+#ifdef __cplusplus
+#include "sphactor.hpp"
+#endif
 
 // structure to pass to the zactor
 typedef struct {

--- a/include/sphactor.hpp
+++ b/include/sphactor.hpp
@@ -1,0 +1,29 @@
+#ifndef SPHACTOR_HPP
+#define SPHACTOR_HPP
+
+template<class SphactorClass>
+SPHACTOR_EXPORT static zmsg_t *
+sphactor_member_handler(sphactor_event_t *ev, void *args)
+{
+    assert(args);
+    SphactorClass *self = static_cast<SphactorClass*>(args);
+    return self->handleMsg(ev);
+};
+
+template<class SphactorClass>
+SPHACTOR_EXPORT sphactor_t *
+sphactor_new ( SphactorClass *inst, const char *name=nullptr, zuuid_t *uuid=nullptr )
+{
+    assert(inst);
+    return sphactor_new(sphactor_member_handler<SphactorClass>, inst, name, uuid);
+}
+
+// void pointer to a costructor
+template<class SphactorClass>
+SPHACTOR_EXPORT void *
+sphactoractor_constructor()
+{
+    return new SphactorClass;
+}
+
+#endif // SPHACTOR_HPP


### PR DESCRIPTION
This might simplify C++ support for Sphactor.

It still needs some way of registering the constructor but this is needed for whole Sphactor.

The C++ interface uses a template to construct the static handler and to add a sphactor_new method which accepts a member method. This does not deal with inheritance which I personally favor.

There's also a template method for registering constructors. However that can only deal with constructors with no arguments.