### PR TITLE
Initial support for Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,75 @@
+version: build-{build}
+
+clone_depth: 1
+
+skip_tags: true
+
+image: Visual Studio 2019
+
+environment:
+  matrix:
+    - platform: Win32
+      configuration: Debug
+    - platform: Win32
+      configuration: Release
+    - platform: x64
+      configuration: Debug
+    - platform: x64
+      configuration: Release
+
+matrix:
+  fast_finish: false
+
+init:
+  - cmake --version
+  - msbuild /version
+  - cmd: reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp" /v UserAuthentication /t REG_DWORD /d 0 /f
+  - cmd: echo "Platform='%env:Platform%'"
+  - cmd: set INSTALL_PREFIX=C:\tmp\ci_build 
+
+install:
+  - cmd: |
+      set LIBZMQ_SOURCEDIR=C:\projects\libzmq
+      set LIBZMQ_BUILDDIR=%LIBZMQ_SOURCEDIR%\build
+      git clone --depth 1 --quiet https://github.com/zeromq/libzmq.git "%LIBZMQ_SOURCEDIR%"
+      md "%LIBZMQ_BUILDDIR%"
+  - cmd: |
+      set CZMQ_SOURCEDIR=C:\projects\czmq
+      set CZMQ_BUILDDIR="%CZMQ_SOURCEDIR%\build"
+      git clone --depth 1 --quiet https://github.com/zeromq/czmq.git "%CZMQ_SOURCEDIR%"
+      md "%CZMQ_BUILDDIR%"
+before_build:
+  - cmd: |
+      cd "%LIBZMQ_BUILDDIR%"
+      cmake .. -DBUILD_STATIC=OFF -DBUILD_SHARED=ON -DZMQ_BUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX="%INSTALL_PREFIX%"
+      cmake --build . --config %Configuration% --target install
+  - cmd: |
+      cd "%CZMQ_BUILDDIR%"
+      cmake .. -DCZMQ_BUILD_STATIC=OFF -DCZMQ_BUILD_SHARED=ON -DCMAKE_PREFIX_PATH="C:\tmp\ci_build" -DCMAKE_INSTALL_PREFIX="%INSTALL_PREFIX%"
+      cmake --build . --config %Configuration% --target install
+#  - cmd: |
+#      cd "%CZMQ_SOURCEDIR%"
+#      cd bindings\jni
+#      gradlew.bat publishToMavenLocal -PbuildPrefix="%INSTALL_PREFIX%" -x test --info
+clone_folder: C:\projects\libsphactor
+
+build_script:
+  - cmd: |
+      set SPH_BUILDDIR="%APPVEYOR_BUILD_FOLDER%\build"
+      md "%SPH_BUILDDIR%"
+      cd "%SPH_BUILDDIR%"
+      cmake .. -DSPHACTOR_BUILD_STATIC=OFF -DSPHACTOR_BUILD_SHARED=ON -DCMAKE_PREFIX_PATH="C:\tmp\ci_build" -DCMAKE_INSTALL_PREFIX="%INSTALL_PREFIX%"
+      cmake --build . --config %Configuration% --target install
+      ctest -C %Configuration% -V
+#  - cmd: |
+#      cd "%APPVEYOR_BUILD_FOLDER%"
+#      cd bindings\jni
+#      gradlew.bat build jar -PbuildPrefix="%INSTALL_PREFIX%" -x test --info
+after_build:
+  - cmd: cd "%SPH_BUILDDIR%\%Configuration%"
+  - cmd: copy "%INSTALL_PREFIX%\bin\*.dll" .
+  - cmd: 7z a -y -bd -mx=9 sphactor.zip sphactor_selftest.exe libzmq*.dll libczmq*.dll libsphactor*.dll
+  - ps: Push-AppveyorArtifact "sphactor.zip" -Filename "sphactor-${env:Platform}-${env:Configuration}.zip"
+
+test:
+  none

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,14 +91,14 @@ configure_file("${PROJECT_BINARY_DIR}/platform.h.in" "${PROJECT_BINARY_DIR}/plat
 if (WIN32)
     #The MSVC C compiler is too out of date,
     #so the sources have to be compiled as c++
-    if (MSVC AND NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
-        enable_language(CXX)
-        file(GLOB sources "${SOURCE_DIR}/src/*.c")
-        set_source_files_properties(
-            ${sources}
-            PROPERTIES LANGUAGE CXX
-        )
-    endif()
+    #if (MSVC AND NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+    #    enable_language(CXX)
+    #    file(GLOB sources "${SOURCE_DIR}/src/*.c")
+    #    set_source_files_properties(
+    #        ${sources}
+    #        PROPERTIES LANGUAGE CXX
+    #    )
+    #endif()
     set(MORE_LIBRARIES ws2_32 Rpcrt4 Iphlpapi)
 endif()
 

--- a/src/sphactor.c
+++ b/src/sphactor.c
@@ -613,7 +613,7 @@ sphactor_test (bool verbose)
     zconfig_destroy(&config);
     sphactor_destroy(&actor1);
     sphactor_destroy(&actor2);
-    
+    zsys_shutdown();  //  needed by Windows: https://github.com/zeromq/czmq/issues/1751
     //  @end
     printf ("OK\n");
 }


### PR DESCRIPTION
This adds an appveyor config which build correctly. The unittest still fails so it still needs fixing.
```
 2: I: 20-06-04 19:08:45 lifecycle_tester: 0, INIT
2: Assertion failed: ev->type == "INIT", file C:\projects\libsphactor\src\sphactor_actor.c, line 431
2: Assertion failed: !s_process_ctx, file C:\projects\czmq\src\zsys.c, line 221
2/2 Test #2: sphactor_actor ...................***Failed    0.33 sec
```
This also changes the CMakeLists.txt which is managed by zproject. So we need to backport this to zproject