### PR TITLE
added actor capability zconfig methods

### DIFF
--- a/api/sphactor.api
+++ b/api/sphactor.api
@@ -137,6 +137,12 @@
         <argument name = "on" type = "boolean" />
     </method>
 
+    <method name = "ask capability">
+        Request the actor's capability. This consists of a zconfig string 
+        containing its capability parameters.
+        <return type = "zconfig" />
+    </method>
+    
     <method name = "set position">
         Set the stage position of the actor.
         <argument name = "x" type = "integer" />

--- a/api/sphactor_actor.api
+++ b/api/sphactor_actor.api
@@ -82,6 +82,19 @@
         <return type = "integer" />
     </method>
 
+    <method name = "capability">
+        Return the capability of the actor as a zconfig instance.
+        <return type = "zconfig" mutable = "0" />
+    </method>
+
+    <method name = "set capability">
+        Set the capability of the actor as a zconfig instance. This should
+        only be done on init and can only be done once!
+        Returns 0 on success, -1 if capability is already set.
+        <argument name = "capability" type = "zconfig" />
+        <return type = "integer" />
+    </method>
+
     <method name = "atomic set report">
         Sets the status report. This is a very specific threadsafe lockfree method 
         to enable the controlling thread to get this actor's status.

--- a/include/sphactor.h
+++ b/include/sphactor.h
@@ -165,6 +165,11 @@ SPHACTOR_EXPORT void
 SPHACTOR_EXPORT void
     sphactor_ask_set_reporting (sphactor_t *self, bool on);
 
+//  Request the actor's capability. This consists of a zconfig string
+//  containing its capability parameters.
+SPHACTOR_EXPORT zconfig_t *
+    sphactor_ask_capability (sphactor_t *self);
+
 //  Set the stage position of the actor.
 SPHACTOR_EXPORT void
     sphactor_set_position (sphactor_t *self, int x, int y);

--- a/include/sphactor_actor.h
+++ b/include/sphactor_actor.h
@@ -88,6 +88,16 @@ SPHACTOR_EXPORT int
 SPHACTOR_EXPORT int
     sphactor_actor_poller_remove (sphactor_actor_t *self, void *fd);
 
+//  Return the capability of the actor as a zconfig instance.
+SPHACTOR_EXPORT const zconfig_t *
+    sphactor_actor_capability (sphactor_actor_t *self);
+
+//  Set the capability of the actor as a zconfig instance. This should
+//  only be done on init and can only be done once!
+//  Returns 0 on success, -1 if capability is already set.
+SPHACTOR_EXPORT int
+    sphactor_actor_set_capability (sphactor_actor_t *self, zconfig_t *capability);
+
 //  Sets the status report. This is a very specific threadsafe lockfree method
 //  to enable the controlling thread to get this actor's status.
 SPHACTOR_EXPORT void
@@ -97,6 +107,11 @@ SPHACTOR_EXPORT void
 //  to enable the controlling thread to get this actor's status.
 SPHACTOR_EXPORT sphactor_report_t *
     sphactor_actor_atomic_report (sphactor_actor_t *self);
+
+//  Sets the actor's osc message for future reports. Use this in
+//  handler functions to store data for use in rendering gui.
+SPHACTOR_EXPORT void
+    sphactor_actor_set_custom_report_data (sphactor_actor_t *self, zosc_t *message);
 
 //  Self test of this class.
 SPHACTOR_EXPORT void


### PR DESCRIPTION
Capability is a zconfig instance describing the capability. As a test this is an example capability:

```
zconfig_str_load(
                  "capabilities\n"
                  "    data\n"
                  "        name = \"rate\"\n"
                  "        type = \"int\"\n"
                  "        value = \"60\"\n"
                  "        min = \"1\"\n"
                  "        max = \"1000\"\n"
                  "        step = \"1\"\n"
                  "    data\n"
                  "        name = \"someFloat\"\n"
                  "        type = \"float\"\n"
                  "        value = \"1.0\"\n"
                  "        min = \"0\"\n"
                  "        max = \"10\"\n"
                  "        step = \"0\"\n"
                  "    data\n"
                  "        name = \"someText\"\n"
                  "        type = \"string\"\n"
                  "        value = \"Hello world!\"\n"
                  "        max = \"64\"\n"
                  );
```