### PR TITLE
Fixes for Record actor

### DIFF
--- a/src/sphactor.c
+++ b/src/sphactor.c
@@ -203,7 +203,8 @@ sphactor_load(const zconfig_t *config)
                 zconfig_t *data = zconfig_locate(root, "data");
                 while ( data ) {
                     zconfig_t *name = zconfig_locate(data, "name");
-                    if (name && streq(zconfig_value(name), cnfNme) )
+                    zconfig_t *type = zconfig_locate(data, "type");
+                    if (name && streq(zconfig_value(name), cnfNme) && !streq(zconfig_value(type), "trigger") )
                     {
                         // TODO: here's the value is set in the capability, this is not safe!!!
                         zconfig_t *value = zconfig_locate(data, "value");

--- a/src/sphactor_actor.c
+++ b/src/sphactor_actor.c
@@ -294,7 +294,7 @@ sphactor_actor_set_timeout (sphactor_actor_t *self, int64_t timeout)
 {
     self->timeout = timeout;
     if (self->timeout >= 0 ) self->time_next = zclock_mono() + self->timeout;
-    else self->time_next = INT_MAX;
+    else self->time_next = INT64_MAX;
 }
 
 int


### PR DESCRIPTION
Fixed int_max error for windows.
Trigger capabilities not sent on load, since this would trigger play/record/stop all at once, causing issues.