### PR TITLE
Expose 0MQ filtering on sub sockets

### DIFF
--- a/api/sphactor.api
+++ b/api/sphactor.api
@@ -143,6 +143,23 @@
         <return type = "integer" />
     </method>
 
+    <method name = "ask filters">
+        Return a list of filters on the incoming socket.
+        Will return NULL if there are no filters.
+        <return type = "zlist" />
+    </method>
+
+    <method name = "ask add filter">
+        Add a filter to the incoming socket. You can add multiple filters. Data will pass if 
+        at least one filter matches the data. Filters are performed bitwise!
+        <argument name = "filter" type = "string" />
+    </method>
+
+    <method name = "ask remove filter">
+        Remove a filter from the incoming socket.
+        <argument name = "filter" type = "string" />
+    </method>
+
     <method name = "connections">
         Return the list of connections of this actor.
         <return type  = "zlist" />

--- a/api/sphactor_actor.api
+++ b/api/sphactor_actor.api
@@ -38,6 +38,25 @@
         <return type = "integer" />
     </method>
 
+    <method name = "filters">
+        Return the list of filters on the incoming subscribe socket.
+        Will return NULL if there are no filters.
+        <return type = "zlist" />
+    </method>
+    
+    <method name = "filter add">
+        Add a filter to the incoming subscribe socket. You can add multiple filters. 
+        Data will pass if at least one filter matches the data. Filters are 
+        performed bitwise! See ZeroMQ subscribe documentation for details.
+        <argument name = "filter" type = "string" />
+    </method>
+
+    <method name = "filter remove">
+        Remove a filter from the incoming subscribe socket. Will do nothing if
+        the filter does not exists.
+        <argument name = "filter" type = "string" />
+    </method>
+
     <method name = "uuid">
         Return our sphactor_actor's UUID string
 

--- a/builds/msvc/vs2015/build.bat
+++ b/builds/msvc/vs2015/build.bat
@@ -19,6 +19,7 @@ SET version=14
 SET log=build.log
 SET tools=Microsoft Visual Studio %version%.0\VC\vcvarsall.bat
 if "%version%" == "15" SET tools=Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat
+if "%version%" == "16" SET tools=Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat
 SET environment="%programfiles(x86)%\%tools%"
 IF NOT EXIST %environment% SET environment="%programfiles%\%tools%"
 IF NOT EXIST %environment% GOTO no_tools

--- a/include/sphactor.h
+++ b/include/sphactor.h
@@ -138,6 +138,20 @@ SPHACTOR_EXPORT int
 SPHACTOR_EXPORT int
     sphactor_ask_disconnect (sphactor_t *self, const char *endpoint);
 
+//  Return a list of filters on the incoming socket.
+//  Will return NULL if there are no filters.
+SPHACTOR_EXPORT zlist_t *
+    sphactor_ask_filters (sphactor_t *self);
+
+//  Add a filter to the incoming socket. You can add multiple filters. Data will pass if
+//  at least one filter matches the data. Filters are performed bitwise!
+SPHACTOR_EXPORT void
+    sphactor_ask_add_filter (sphactor_t *self, const char *filter);
+
+//  Remove a filter from the incoming socket.
+SPHACTOR_EXPORT void
+    sphactor_ask_remove_filter (sphactor_t *self, const char *filter);
+
 //  Return the list of connections of this actor.
 SPHACTOR_EXPORT zlist_t *
     sphactor_connections (sphactor_t *self);

--- a/include/sphactor_actor.h
+++ b/include/sphactor_actor.h
@@ -54,6 +54,22 @@ SPHACTOR_EXPORT int
 SPHACTOR_EXPORT int
     sphactor_actor_disconnect (sphactor_actor_t *self, const char *dest);
 
+//  Return the list of filters on the incoming subscribe socket.
+//  Will return NULL if there are no filters.
+SPHACTOR_EXPORT zlist_t *
+    sphactor_actor_filters (sphactor_actor_t *self);
+
+//  Add a filter to the incoming subscribe socket. You can add multiple filters.
+//  Data will pass if at least one filter matches the data. Filters are
+//  performed bitwise! See ZeroMQ subscribe documentation for details.
+SPHACTOR_EXPORT void
+    sphactor_actor_filter_add (sphactor_actor_t *self, const char *filter);
+
+//  Remove a filter from the incoming subscribe socket. Will do nothing if
+//  the filter does not exists.
+SPHACTOR_EXPORT void
+    sphactor_actor_filter_remove (sphactor_actor_t *self, const char *filter);
+
 //  Return our sphactor_actor's UUID string
 //
 //  Note: sphactor_actor methods can only be called from within its instance!

--- a/include/sphactor_report.h
+++ b/include/sphactor_report.h
@@ -24,14 +24,22 @@ extern "C" {
 //  @interface
 //  This is a stable class, and may not change except for emergencies. It
 //  is provided in stable builds.
-#define SPHACTOR_REPORT_INIT 0               //
-#define SPHACTOR_REPORT_IDLE 1               //
-#define SPHACTOR_REPORT_STOP 2               //
-#define SPHACTOR_REPORT_DESTROY 3            //
-#define SPHACTOR_REPORT_SOCK 4               //
-#define SPHACTOR_REPORT_TIME 5               //
-#define SPHACTOR_REPORT_FDSOCK 6             //
-#define SPHACTOR_REPORT_API 7                //
+
+#define SPHACTOR_REPORT_INIT 0
+
+#define SPHACTOR_REPORT_IDLE 1
+
+#define SPHACTOR_REPORT_STOP 2
+
+#define SPHACTOR_REPORT_DESTROY 3
+
+#define SPHACTOR_REPORT_SOCK 4
+
+#define SPHACTOR_REPORT_TIME 5
+
+#define SPHACTOR_REPORT_FDSOCK 6
+
+#define SPHACTOR_REPORT_API 7
 
 //  Constructor, creates a new Sphactor_report instance.
 SPHACTOR_EXPORT sphactor_report_t *

--- a/src/sph_stage.c
+++ b/src/sph_stage.c
@@ -82,14 +82,15 @@ sph_stage_cnf_load(sph_stage_t *self, const zconfig_t *cnf)
     while( actor_conf != NULL )
     {
         sphactor_t *new_actor =  sphactor_load(actor_conf);
-        assert(new_actor);
+        if (new_actor)
+        {
+            // save actor
+            int rc = zhash_insert(self->actors, zuuid_str(sphactor_ask_uuid(new_actor)), new_actor);
+            assert( rc == 0);
 
-        // save actor
-        int rc = zhash_insert(self->actors, zuuid_str(sphactor_ask_uuid(new_actor)), new_actor);
-        assert( rc == 0);
-
-        // load settings for actor
-        //sph_deserialise_actor_data(new_actor, actor_conf);
+            // load settings for actor
+            //sph_deserialise_actor_data(new_actor, actor_conf);
+        }
 
         actor_conf = zconfig_next(actor_conf);
     }

--- a/src/sphactor.c
+++ b/src/sphactor.c
@@ -178,7 +178,11 @@ sphactor_load(const zconfig_t *config)
     zuuid_set_str(uid, uuidStr);
     // create actor
     sphactor_t* new_actor = sphactor_new_by_type(typeStr, nameStr, uid);
-    assert(new_actor);
+    if ( new_actor == NULL)
+    {
+        zsys_error("Failed to create actor type %s", typeStr);
+        return NULL;
+    }
 
     // set position
     sphactor_set_position( new_actor, atof(xposStr), atof(yposStr) );

--- a/src/sphactor.c
+++ b/src/sphactor.c
@@ -1510,7 +1510,7 @@ sphactor_test (bool verbose)
         filters = sphactor_ask_filters(filteract);
         assert(filters != NULL);
         assert(zlist_size(filters) == 1);
-        char *filter = zlist_first(filters);
+        char *filter = (char *)zlist_first(filters);
         assert( streq(filter, "test") );
         zlist_destroy(&filters);
         assert(filters == NULL);

--- a/src/sphactor_actor.c
+++ b/src/sphactor_actor.c
@@ -286,11 +286,11 @@ sphactor_actor_filter_add (sphactor_actor_t *self, const char *filter)
         zlist_comparefn (self->sub_filters, (zlist_compare_fn *) strcmp);
         assert(self->sub_filters);
     }
-    else if ( zlist_exists(self->sub_filters, filter) ) return;
+    else if ( zlist_exists(self->sub_filters, (void *)filter) ) return;
 
     zsock_set_subscribe(self->sub, filter);
 
-    int rc = zlist_append(self->sub_filters, filter);
+    int rc = zlist_append(self->sub_filters, (void *)filter);
     assert(rc == 0);
 }
 
@@ -302,7 +302,7 @@ sphactor_actor_filter_remove (sphactor_actor_t *self, const char *filter)
     assert(self);
     assert(filter);
     if (self->sub_filters == NULL ) return;
-    zlist_remove(self->sub_filters, filter);
+    zlist_remove(self->sub_filters, (void *)filter);
     if (zlist_size(self->sub_filters) == 0)
     {
         // no more filter so add empty filter so no messages are blocked
@@ -486,11 +486,11 @@ sphactor_actor_recv_api (sphactor_actor_t *self)
         zmsg_t *ret = zmsg_new();
         if (filters)
         {
-            char *f = zlist_first(filters);
+            char *f = (char *)zlist_first(filters);
             while(f != NULL)
             {
                 zmsg_addstr(ret, f);
-                f = zlist_next(filters);
+                f = (char *)zlist_next(filters);
             }
         }
         else


### PR DESCRIPTION
This adds methods to add and remove filters on subscribe sockets (the receiving socket of the actor). Filtering is actually done on the pub sockets (sender side). So if a filter doesn't match the message isn't even send.

example:
```c
        sphactor_t *filteract = sphactor_new(api_sphactor, NULL, NULL, NULL);
        sphactor_t *senderact = sphactor_new(api_sphactor, NULL, NULL, NULL);
        int rc = sphactor_ask_connect(filteract, sphactor_ask_endpoint(senderact));
        assert(rc == 0);
        sphactor_ask_add_filter(filteract, "TEST"); // add a TEST filter
        sphactor_ask_api(senderact, "SEND", "s", "TESTAPI"); // this one is received
        sphactor_ask_api(senderact, "SEND", "s", "BLAA"); // this one is not received
```


I see this PR also fixes an issue with loading not registered (unknown) actors. Oops, but a very welcome fix